### PR TITLE
Downloading bootstrap into the themes folder

### DIFF
--- a/productivity/drupal-org.make
+++ b/productivity/drupal-org.make
@@ -143,3 +143,4 @@ libraries[dompdf][download][url] = "https://github.com/dompdf/dompdf/releases/do
 ; Themes
 projects[bootstrap][subdir] = "contrib"
 projects[bootstrap][version] = "3.x-dev"
+projects[bootstrap][type] = "theme"


### PR DESCRIPTION
Without this bootstrap gets downloaded to the modules folder, and it causes these errors:
![screen shot 2015-12-03 at 12 08 35 pm](https://cloud.githubusercontent.com/assets/2283680/11557747/0bb4a670-99b7-11e5-986e-74351b80a98d.png)
