### PR TITLE
Fixing bootstrap installation path

### DIFF
--- a/productivity/drupal-org.make
+++ b/productivity/drupal-org.make
@@ -147,3 +147,4 @@ libraries[dompdf][download][url] = "https://github.com/dompdf/dompdf/releases/do
 ; Themes
 projects[bootstrap][subdir] = "contrib"
 projects[bootstrap][version] = "3.x-dev"
+projects[bootstrap][type] = "theme"


### PR DESCRIPTION
When not setting the type, bootstrap may be downloaded to the modules dir instead of the themes dir.