### PR TITLE
Fix makefile.

### DIFF
--- a/productivity/drupal-org.make
+++ b/productivity/drupal-org.make
@@ -39,6 +39,7 @@ projects[entityreference][patch][] = "https://www.drupal.org/files/issues/migrat
 projects[entityreference_filter][subdir] = "contrib"
 projects[entityreference_filter][version] = "1.5"
 
+projects[entityrelationships][type] = "module"
 projects[entityrelationships][subdir] = "contrib"
 projects[entityrelationships][download][type] = "git"
 projects[entityrelationships][download][url] = "git@github.com:Gizra/entityrelationships.git"
@@ -141,7 +142,7 @@ projects[migrate_extras][version] = "2.5"
 ; Libraries
 libraries[dompdf][type] = "libraries"
 libraries[dompdf][download][type] = "get"
-libraries[dompdf][download][url] = "https://github.com/dompdf/dompdf/releases/download/v0.6.1/dompdf-0.6.1.zip"
+libraries[dompdf][download][url] = "https://github.com/dompdf/dompdf/archive/v0.6.1.zip"
 
 ; Themes
 projects[bootstrap][subdir] = "contrib"


### PR DESCRIPTION
@bricel 
Couldn't reinstall the site - fixed the makefile.

Notice dompdf library was updated with **several** critical security fixes. I kept it the same version since I'm not sure which thing I'd have to test after changing.

https://github.com/dompdf/dompdf/releases/tag/v0.6.2

I'll be counting on this PR to move ahead with #178 (if it's still relevant) next week.