### PR TITLE
pantheon/db_sanitization.php: At Pantheon DB sanitization, use {} to …

### DIFF
--- a/scripts/pantheon/db_sanitization.php
+++ b/scripts/pantheon/db_sanitization.php
@@ -14,5 +14,5 @@ if (defined('PANTHEON_ENVIRONMENT') && (PANTHEON_ENVIRONMENT !== 'live')) {
   require_once DRUPAL_ROOT . '/includes/bootstrap.inc';
   drupal_bootstrap(DRUPAL_BOOTSTRAP_DATABASE);
   // From http://crackingdrupal.com/blog/greggles/creating-sanitized-drupal-database-dump#comment-164
-  db_query("UPDATE users SET mail = CONCAT(name, '@test'), init = CONCAT(name, '@test');");
+  db_query("UPDATE {users} SET mail = CONCAT(name, '@test'), init = CONCAT(name, '@test');");
 }


### PR DESCRIPTION
…let Drupal handle the real table name resolution, even if Pantheon does not support that configuration officially (https://pantheon.io/docs/mysql-access/#frequently-asked-questions), it can be the case anytime in the future