### PR TITLE
Fix access denied in case of private membership

### DIFF
--- a/client/app/views/login.html
+++ b/client/app/views/login.html
@@ -10,7 +10,7 @@
         <div class="row">
 
           <div class="col-xs-12" ng-if="githubClientId">
-            <a class="btn btn-block btn-social btn-lg btn-github text-center" ng-href="https://github.com/login/oauth/authorize?client_id={{ githubClientId }}&scope=user:email">
+            <a class="btn btn-block btn-social btn-lg btn-github text-center" ng-href="https://github.com/login/oauth/authorize?client_id={{ githubClientId }}&scope=user:email,read:org">
               <i class="fa fa-github"></i> Login with GitHub account
             </a>
             <div class="alert alert-danger" ng-if="loginErrorMessage">


### PR DESCRIPTION
The https://github.com/Gizra/productivity/pull/356 was tested by a user key with many permissions, but we only ask very limited permissions (aka scope) from GitHub. 
With one more scope, we are able to read private membership info too (https://developer.github.com/v3/oauth/#scopes).

#358 